### PR TITLE
Issue 69 - Help command

### DIFF
--- a/json/locations.json
+++ b/json/locations.json
@@ -1,1 +1,127 @@
-{"2,7,-1": {"title": "Dark Corridor", "coordinate": "2,7,-1", "description": "A very long dark corridor", "locationType": "CAVE"}, "0,4,-1": {"title": "Underground Entrance", "coordinate": "0,4,-1", "description": "The entrance to Silliya's Underground Society", "locationType": "CAVE", "items" : [ "tlap1" ] }, "-3,5,-1": {"title": "Dark Corridor", "coordinate": "-3,5,-1", "description": "A very long dark corridor", "locationType": "CAVE"}, "0,6,-1": {"title": "Dark Corridor", "coordinate": "0,6,-1", "description": "A very long dark corridor", "locationType": "CAVE"}, "0,-1,-1": {"title": "Stairs", "coordinate": "0,-1,-1", "description": "Stairs up to the outside world.", "locationType": "CAVE"}, "1,1,-1": {"title": "Dark Corridor", "coordinate": "1,1,-1", "description": "A very long dark corridor", "locationType": "CAVE"}, "2,9,-1": {"title": "Dark Corridor", "coordinate": "2,9,-1", "description": "A very long dark corridor", "locationType": "CAVE"}, "2,6,-1": {"title": "Dark Corridor", "coordinate": "2,6,-1", "description": "A very long dark corridor", "locationType": "CAVE"}, "1,6,-1": {"title": "Dark Corridor", "coordinate": "1,6,-1", "description": "A very long dark corridor", "locationType": "CAVE"}, "0,1,-1": {"title": "Dark Corridor", "coordinate": "0,1,-1", "description": "A very long dark corridor.", "locationType": "CAVE"}, "0,3,-1": {"title": "Dark Corridor", "coordinate": "0,3,-1", "description": "A very long dark corridor", "locationType": "CAVE"}, "-3,6,-1": {"title": "Dark Corridor", "coordinate": "-3,6,-1", "description": "A very long dark corridor", "locationType": "CAVE"}, "-2,6,-1": {"title": "Dark Corridor", "coordinate": "-2,6,-1", "description": "A very long dark corridor", "locationType": "CAVE"}, "0,0,-1": {"title": "First Location Ever", "coordinate": "0,0,-1", "description": "You are in a massive, empty room.", "locationType": "CAVE", "items" : [ "fmil1" ], "npcs" : [ "guide" ]}, "-1,6,-1": {"title": "Dark Corridor", "coordinate": "-1,6,-1", "description": "A very long dark corridor", "locationType": "CAVE"}, "0,2,-1": {"title": "Dark Corridor", "coordinate": "0,2,-1", "description": "A very long dark corridor", "locationType": "CAVE"}, "0,5,-1": {"title": "Dark Corridor", "coordinate": "0,5,-1", "description": "A very long dark corridor", "locationType": "CAVE"}, "2,8,-1": {"title": "Dark Corridor", "coordinate": "2,8,-1", "description": "A very long dark corridor", "locationType": "CAVE"}, "2,10,-1": {"title": "Underground Amphitheatre", "coordinate": "2,10,-1", "description": "The central hub of the underground", "locationType": "CAVE", "items" : [ "wshi1" ]}}
+{
+	"2,7,-1": {
+		"title": "Dark Corridor", 
+		"coordinate": "2,7,-1", 
+		"description": "A very long dark corridor", 
+		"locationType": "CAVE"
+	},
+       	"0,4,-1": {
+		"title": "Underground Entrance", 
+		"coordinate": "0,4,-1", 
+		"description": "The entrance to Silliya's Underground Society", 
+		"locationType": "CAVE", 
+		"items" : [ 
+			"tlap1" 
+			] 
+		}, 
+		"-3,5,-1": {
+			"title": "Dark Corridor", 
+			"coordinate": "-3,5,-1", 
+			"description": "A very long dark corridor",
+		       	"locationType": "CAVE"
+		}, 
+		"0,6,-1": {
+			"title": "Dark Corridor", 
+			"coordinate": "0,6,-1", 
+			"description": "A very long dark corridor",
+		       	"locationType": "CAVE"
+		}, 
+		"0,-1,-1": {
+			"title": "Stairs", 
+			"coordinate": "0,-1,-1", 
+			"description": "Stairs up to the outside world.", 
+			"locationType": "CAVE"
+		}, 
+		"1,1,-1": {
+			"title": "Dark Corridor", 
+			"coordinate": "1,1,-1", 
+			"description": "A very long dark corridor", 
+			"locationType": "CAVE"
+		},
+		"2,9,-1": {
+			"title": "Dark Corridor", 
+			"coordinate": "2,9,-1", 
+			"description": "A very long dark corridor", 
+			"locationType": "CAVE"
+		}, "2,6,-1": {
+			"title": "Dark Corridor", 
+			"coordinate": "2,6,-1", 
+			"description": "A very long dark corridor", 
+			"locationType": "CAVE"
+		}, 
+		"1,6,-1": 
+		{"title": "Dark Corridor", 
+			"coordinate": "1,6,-1", 
+			"description": "A very long dark corridor", 
+			"locationType": "CAVE"
+		},
+	       	"0,1,-1": {
+			"title": "Dark Corridor", 
+			"coordinate": "0,1,-1", 
+			"description": "A very long dark corridor.", 
+			"locationType": "CAVE"
+		},
+	       	"0,3,-1": {
+			"title": "Dark Corridor", 
+			"coordinate": "0,3,-1", 
+			"description": "A very long dark corridor", 
+			"locationType": "CAVE"
+		}, 
+		"-3,6,-1": {
+			"title": "Dark Corridor", 
+			"coordinate": "-3,6,-1", 
+			"description": "A very long dark corridor", 
+			"locationType": "CAVE"
+		},
+		"-2,6,-1": {
+			"title": "Dark Corridor", 
+			"coordinate": "-2,6,-1", 
+			"description": "A very long dark corridor", 
+			"locationType": "CAVE"
+		},
+		"0,0,-1": {
+			"title": "First Location Ever", 
+			"coordinate": "0,0,-1", 
+			"description": "You are in a massive, empty room.", 
+			"locationType": "CAVE", 
+			"items" : [ 
+				"fmil1" 
+				], 
+			"npcs" : [
+			       	"guide" 
+				]
+		}, 
+		"-1,6,-1": {
+			"title": "Dark Corridor", 
+			"coordinate": "-1,6,-1", 
+			"description": "A very long dark corridor", 
+			"locationType": "CAVE"
+		}, 
+		"0,2,-1": {
+			"title": "Dark Corridor", 
+			"coordinate": "0,2,-1", 
+			"description": "A very long dark corridor", 
+			"locationType": "CAVE"
+		}, 
+		"0,5,-1": {
+			"title": "Dark Corridor", 
+			"coordinate": "0,5,-1", 
+			"description": "A very long dark corridor", 
+			"locationType": "CAVE"
+		}, 
+		"2,8,-1": {
+			"title": "Dark Corridor", 
+			"coordinate": "2,8,-1", 
+			"description": "A very long dark corridor", 
+			"locationType": "CAVE"
+		}, 
+		"2,10,-1": {
+			"title": "Underground Amphitheatre", 
+			"coordinate": "2,10,-1", 
+			"description": "The central hub of the underground", 
+			"locationType": "CAVE", 
+			"items" : [ 
+				"wshi1" 
+				]
+		}
+}

--- a/src/main/java/com/jadventure/game/prompts/CommandCollection.java
+++ b/src/main/java/com/jadventure/game/prompts/CommandCollection.java
@@ -44,12 +44,12 @@ public enum CommandCollection {
 "debug: starts debuggung.\n";
 
     private HashMap<String, String> directionLinks = new HashMap<String,String>()
-    {
+    {{
          put("n", "north");
          put("s", "south");
          put("e", "east");
          put("w", "west");
-    };
+    }};
 
     public static CommandCollection getInstance() {
         return INSTANCE;

--- a/src/site/apt/development/use-case/use-case-10-command-look.apt
+++ b/src/site/apt/development/use-case/use-case-10-command-look.apt
@@ -14,7 +14,7 @@ UC-10 Command Look
   
 * Main Success Scenario
 
-  * player types command 'look' <<<look>>>
+  * player types command 'lookround' <<<la>>>
 
   * Return a description of the location and of the things possibly seen here like:
   


### PR DESCRIPTION
Improved help layout. Added lookaround ("la") command to print out the description of the location. Added unequip command - same as dequip, except more intuitive as it is correct English.

Reference - issue [#69](https://github.com/Progether/JAdventure/issues/69)
