### PR TITLE
Added 'dist' option for build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -52,6 +52,15 @@
       </manifest>
     </jar>
   </target>
+
+  <target name="dist" depends="jar">
+    <copy todir="${jar.dir}/lib">
+        <fileset dir="lib" />
+     </copy>
+     <copy todir="${jar.dir}/json">
+	 <fileset dir="json" />
+     </copy>
+  </target>
   
   <target name="junit" depends="jar">
     <junit printsummary="yes" haltonfailure="yes" >


### PR DESCRIPTION
Creates a directory "jar" in the build directory that contains the .jar and all required files for distribution.
