### PR TITLE
#167 Fixes storing of Items (now in alphabetic order)

### DIFF
--- a/src/main/java/com/jadventure/game/items/Item.java
+++ b/src/main/java/com/jadventure/game/items/Item.java
@@ -1,8 +1,8 @@
 package com.jadventure.game.items;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 import com.jadventure.game.QueueProvider;
 import com.jadventure.game.entities.EquipmentLocation;
@@ -33,7 +33,7 @@ public class Item {
             this.properties = properties;
         }
         else {
-            this.properties = new HashMap<>();
+            this.properties = new TreeMap<>();
         }
     }
 

--- a/src/main/java/com/jadventure/game/repository/ItemRepository.java
+++ b/src/main/java/com/jadventure/game/repository/ItemRepository.java
@@ -6,6 +6,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -74,7 +75,7 @@ public class ItemRepository {
             EquipmentLocation position = EQUIPMENT_POSITION_MAP.get(itemData.get("position").getAsString());
             int level = itemData.get("level").getAsInt();
             JsonObject sProps = itemData.get("properties").getAsJsonObject();
-            Map<String, Integer> properties = new HashMap<>();
+            Map<String, Integer> properties = new TreeMap<>();
             for (Map.Entry<String, JsonElement> entry2 : sProps.entrySet()) {
                 Integer propValue = entry2.getValue().getAsInt();
                 properties.put(entry2.getKey(), propValue);
@@ -119,7 +120,7 @@ public class ItemRepository {
     public void store(JsonWriter writer) {
         GsonBuilder bldr = new GsonBuilder().setPrettyPrinting();
         Gson gson = bldr.create();
-        Map<String, Map<String, Item>> root = new HashMap<>();
+        Map<String, Map<String, Item>> root = new TreeMap<>();
         root.put("items", itemMap);
         gson.toJson(root, Map.class, writer);
     }

--- a/src/test/java/com/jadventure/game/items/ItemTest.java
+++ b/src/test/java/com/jadventure/game/items/ItemTest.java
@@ -5,8 +5,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.junit.Test;
 
@@ -41,7 +41,7 @@ public class ItemTest {
 	}
 
     private Item createMilk() {
-        Map<String, Integer> properties = new HashMap<>();
+        Map<String, Integer> properties = new TreeMap<>();
         properties.put("health", Integer.valueOf(5));
         properties.put("weight", Integer.valueOf(1));
         properties.put("value", Integer.valueOf(10));
@@ -51,7 +51,7 @@ public class ItemTest {
     }
 
     private Item createEgg() {
-        Map<String, Integer> properties = new HashMap<>();
+        Map<String, Integer> properties = new TreeMap<>();
         properties.put("health", Integer.valueOf(2));
         properties.put("weight", Integer.valueOf(1));
         properties.put("value", Integer.valueOf(3));

--- a/src/test/java/com/jadventure/game/repository/ItemRepositoryTest.java
+++ b/src/test/java/com/jadventure/game/repository/ItemRepositoryTest.java
@@ -11,6 +11,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.junit.Test;
 
@@ -67,9 +68,9 @@ public class ItemRepositoryTest {
         
         String expected = "{\"items\":{"
                 + "\"egg-1\":{\"id\":\"egg-1\",\"type\":\"food\",\"name\":\"egg\",\"description\":\"A nice egg\","
-                + "\"level\":1,\"properties\":{\"weight\":1,\"value\":3,\"health\":2}},"
+                + "\"level\":1,\"properties\":{\"health\":2,\"value\":3,\"weight\":1}},"
                 + "\"milk-bottle\":{\"id\":\"milk-bottle\",\"type\":\"potion\",\"name\":\"milk\",\"description\":\"Milk in a bottle\","
-                + "\"level\":1,\"properties\":{\"weight\":1,\"value\":10,\"health\":5}}"
+                + "\"level\":1,\"properties\":{\"health\":5,\"value\":10,\"weight\":1}}"
                 + "}}";
         String gsonMsg = writer.toString();
         assertEquals(expected, gsonMsg);
@@ -117,7 +118,7 @@ public class ItemRepositoryTest {
     }
     
     private Item createMilk() {
-        Map<String, Integer> properties = new HashMap<>();
+        Map<String, Integer> properties = new TreeMap<>();
         properties.put("health", Integer.valueOf(5));
         properties.put("weight", Integer.valueOf(1));
         properties.put("value", Integer.valueOf(10));
@@ -127,7 +128,7 @@ public class ItemRepositoryTest {
     }
 
     private Item createEgg() {
-        Map<String, Integer> properties = new HashMap<>();
+        Map<String, Integer> properties = new TreeMap<>();
         properties.put("health", Integer.valueOf(2));
         properties.put("weight", Integer.valueOf(1));
         properties.put("value", Integer.valueOf(3));


### PR DESCRIPTION
Item properties are now stored in a TreeMap (which is a sorted map), so items are in alphabetic order written to the JSON writer, which should always be in the same order. Before the HashMap has no order so can be different from run to run, or platform to platform / implementation.
