### PR TITLE
fixed #121 where monsters and npcs can hold items

### DIFF
--- a/src/main/java/com/jadventure/game/menus/BattleMenu.java
+++ b/src/main/java/com/jadventure/game/menus/BattleMenu.java
@@ -7,8 +7,13 @@ import com.jadventure.game.entities.NPC;
 import com.jadventure.game.monsters.Monster;
 import com.jadventure.game.QueueProvider;
 import com.jadventure.game.CharacterChange;
+import com.jadventure.game.items.ItemStack;
+import com.jadventure.game.items.Item;
+import com.jadventure.game.GameBeans;
 
 import java.util.Random;
+import java.util.List;
+import java.util.ArrayList;
 
 public class BattleMenu extends Menus {
 
@@ -55,7 +60,24 @@ public class BattleMenu extends Menus {
             int oldLevel = this.player.getLevel();
             int newLevel = (int) (0.075 * Math.sqrt(this.player.getXP()) + 1);
             this.player.setLevel(newLevel);
-            //this.player.getLocation().removeMonster(npcOpponent);
+
+            // Iterates over the npc's items and if there are any, drops them. 
+            // There are two loops due to a ConcurrentModification Exception that occurs
+            // if you try to remove the item while looping through the npc's items.
+            List<ItemStack> itemStacks = npcOpponent.getStorage().getItems();
+            List<String> itemIds = new ArrayList<>();
+            for (ItemStack itemStack : itemStacks) {
+                String itemId = itemStack.getItem().getId();
+                itemIds.add(itemId);
+            }
+            for (String itemId : itemIds) {
+                Item item = GameBeans.getItemRepository().getItem(itemId);
+                npcOpponent.removeItemFromStorage(item);
+                this.player.getLocation().addPublicItem(item.getId());
+                QueueProvider.offer("Your opponent dropped a " + item.getName());
+            }
+
+            this.player.getLocation().removeNPC(npcOpponent);
             this.player.setGold(this.player.getGold() + npcOpponent.getGold());
             QueueProvider.offer("You killed a " + npcOpponent.getName() + "\nYou have gained " + xp + " XP and " + npcOpponent.getGold() + " gold");
             if (oldLevel < newLevel) {
@@ -101,6 +123,23 @@ public class BattleMenu extends Menus {
             int oldLevel = this.player.getLevel();
             int newLevel = (int) (0.075 * Math.sqrt(this.player.getXP()) + 1);
             this.player.setLevel(newLevel);
+
+            // Iterates over monster's items and if there are any, drops them. 
+            // There are two loops due to a ConcurrentModification Exception that occurs
+            // if you try to remove the item while looping through the monster's items.
+            List<ItemStack> itemStacks = monsterOpponent.getStorage().getItems();
+            List<String> itemIds = new ArrayList<>();
+            for (ItemStack itemStack : itemStacks) {
+                String itemId = itemStack.getItem().getId();
+                itemIds.add(itemId);
+            }
+            for (String itemId : itemIds) {
+                Item item = GameBeans.getItemRepository().getItem(itemId);
+                monsterOpponent.removeItemFromStorage(item);
+                this.player.getLocation().addPublicItem(item.getId());
+                QueueProvider.offer("Your opponent dropped a " + item.getName());
+            }
+
             this.player.getLocation().removeMonster(monsterOpponent);
             this.player.setGold(this.player.getGold() + monsterOpponent.getGold());
             QueueProvider.offer("You killed a " + monsterOpponent.getName() + "\nYou have gained " + xp + " XP and " + monsterOpponent.getGold() + " gold");

--- a/src/main/java/com/jadventure/game/monsters/Bugbear.java
+++ b/src/main/java/com/jadventure/game/monsters/Bugbear.java
@@ -16,8 +16,8 @@ public class Bugbear extends Monster {
                 this.setStealth(1);
                 this.setDexterity(1);
 		this.setCritChance(0.02);
-        this.setXPGain(30 + playerLevel * 3);
-		this.setGold(playerLevel * 3);
-	    this.getStorage().addItem(new ItemStack(1, itemRepo.getItem("pmil1")));
+                this.setXPGain(30 + playerLevel * 3);
+                this.setGold(playerLevel * 3);
+                addRandomItems(playerLevel, "fram1", "pmil1");
 	}
 }

--- a/src/main/java/com/jadventure/game/monsters/Giant.java
+++ b/src/main/java/com/jadventure/game/monsters/Giant.java
@@ -14,7 +14,8 @@ public class Giant extends Monster {
                 this.setStealth(1);
                 this.setDexterity(1);
 		this.setCritChance(0.03);
-        this.setXPGain(50 + playerLevel * 3);
+                this.setXPGain(50 + playerLevel * 3);
 		this.setGold(15 + playerLevel * 11);
+                addRandomItems(playerLevel, "wrbd1");
 	}
 }

--- a/src/main/java/com/jadventure/game/monsters/Goblin.java
+++ b/src/main/java/com/jadventure/game/monsters/Goblin.java
@@ -14,7 +14,8 @@ public class Goblin extends Monster {
                 this.setStealth(2);
                 this.setDexterity(1);
 		this.setCritChance(0.02);
-        this.setXPGain(10 + playerLevel * 3);
+                this.setXPGain(10 + playerLevel * 3);
 		this.setGold(playerLevel * 5);
+                addRandomItems(playerLevel, "wdag1", "agre1", "albt1", "algt1");
 	}
 }

--- a/src/main/java/com/jadventure/game/monsters/Monster.java
+++ b/src/main/java/com/jadventure/game/monsters/Monster.java
@@ -1,6 +1,13 @@
 package com.jadventure.game.monsters;
 
 import com.jadventure.game.entities.Entity;
+import com.jadventure.game.items.Item;
+import com.jadventure.game.GameBeans;
+import com.jadventure.game.repository.ItemRepository;
+
+import java.util.List;
+import java.util.Arrays;
+import java.util.Random;
 
 /*
  * This class just holds a type of monster that is 
@@ -8,8 +15,9 @@ import com.jadventure.game.entities.Entity;
  * just holds the monster's name.
  */
 public abstract class Monster extends Entity {
-	public String monsterType;
+    public String monsterType;
     private int xpGain;
+    private ItemRepository itemRepo = GameBeans.getItemRepository();
 
     public int getXPGain() {
         return xpGain;
@@ -29,5 +37,27 @@ public abstract class Monster extends Entity {
             return m.monsterType.equals(this.monsterType);
         }
         return false;
+    }
+
+    public void addRandomItems(int playerLevel, String... children) {
+        List<String> itemList = Arrays.asList(children);
+        Random rand = new Random();
+
+        int numItems = 1;
+        int i = 0;
+        while (i != numItems) {
+            for (String itemName : itemList) {
+                if (i == numItems) {
+                    break;
+                }
+
+                int j = rand.nextInt(5) + 1;
+                if (j == 1) {
+                    Item item = itemRepo.getItem(itemName);
+                    addItemToStorage(item);
+                    i++;
+                }
+            }
+        }
     }
 }

--- a/src/main/java/com/jadventure/game/monsters/Skeleton.java
+++ b/src/main/java/com/jadventure/game/monsters/Skeleton.java
@@ -16,5 +16,6 @@ public class Skeleton extends Monster {
                 this.setDexterity(3);        
                 this.setXPGain(10 + playerLevel * 3);
 		this.setGold(playerLevel * 3);
+                addRandomItems(playerLevel, "arhl1");
 	}
 }

--- a/src/main/java/com/jadventure/game/monsters/Troll.java
+++ b/src/main/java/com/jadventure/game/monsters/Troll.java
@@ -16,5 +16,6 @@ public class Troll extends Monster {
                 this.setDexterity(1);
                 this.setXPGain(75 + playerLevel * 3);
 		this.setGold(25 + playerLevel * 10);
+                addRandomItems(playerLevel, "wbrd1", "ashi1", "pmil2");
 	}
 }

--- a/src/main/java/com/jadventure/game/monsters/Wolf.java
+++ b/src/main/java/com/jadventure/game/monsters/Wolf.java
@@ -16,5 +16,6 @@ public class Wolf extends Monster {
                 this.setDexterity(2);
                 this.setXPGain(25 + playerLevel * 3);
 		this.setGold(playerLevel * 2);
+                addRandomItems(playerLevel, "fram1");
 	}
 }

--- a/src/main/java/com/jadventure/game/navigation/ILocation.java
+++ b/src/main/java/com/jadventure/game/navigation/ILocation.java
@@ -32,6 +32,7 @@ public interface ILocation {
     List<Monster> getMonsters();
     void addMonster(Monster monster);
     void removeMonster(Monster monster);
+    void removeNPC(NPC npc);
 
     void print();
     int getDangerRating();

--- a/src/main/java/com/jadventure/game/navigation/Location.java
+++ b/src/main/java/com/jadventure/game/navigation/Location.java
@@ -138,6 +138,14 @@ public class Location implements ILocation {
             }
         }
     }
+    
+    public void removeNPC(NPC npc) {
+        for (int i = 0; i < npcs.size(); i++) {
+            if (npcs.get(i).equals(npc)) {
+                npcs.remove(i);
+            }
+        }
+    }
 
     public List<Monster> getMonsters() {
         return monsters;


### PR DESCRIPTION
This commit fixes #121 so that monsters can hold items other than gold and xp. It works by adding another line in each monster's java file that calls AddRandomItems and passes in the playerlevel and a variable amount of itemIds. The function that randomly chooses one of the items and adds it into the monster's items. 

When you kill the monter or the npc, it drops the items and notifies you about the drop. In the future we may want to expand the amount of items that are randomly assigned to the monster based on the playerLevel but I figured for right now, one random item is more than enough especially considering the amount of monsters laying around the underground. 

I also fixed a bug where npcs where not being removed from the map when they were killed (i.e the Brotherhood Member). 
