### PR TITLE
Use gold to weight NPCs between selling and buying

### DIFF
--- a/json/original_data/npcs.json
+++ b/json/original_data/npcs.json
@@ -124,7 +124,7 @@
       "intelligence": 2,
       "dexterity": 2,
       "stealth": 2,
-      "gold": 100,
+      "gold": 50,
       "location": [
         {
           "head": "empty"
@@ -202,7 +202,7 @@
       "intelligence": 1,
       "dexterity": 1,
       "stealth": 1,
-      "gold": 100,
+      "gold": 50,
       "location": [
         {
           "head": "empty"


### PR DESCRIPTION
A NPC with more gold is primarily a buyer and one with less is a Seller.

Fixes #206