### PR TITLE
Feature/multiple aliases

### DIFF
--- a/src/main/java/com/jadventure/game/prompts/Command.java
+++ b/src/main/java/com/jadventure/game/prompts/Command.java
@@ -9,7 +9,7 @@ import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Command {
     String command();
-    String aliases();
+    String[] aliases();
     String description();
     boolean debug();
 }

--- a/src/main/java/com/jadventure/game/prompts/CommandCollection.java
+++ b/src/main/java/com/jadventure/game/prompts/CommandCollection.java
@@ -107,13 +107,13 @@ public enum CommandCollection {
         }
     }
 
-    @Command(command="save", aliases="s", description="Save the game", debug=false)
+    @Command(command="save", aliases={"s"}, description="Save the game", debug=false)
     public void command_save() {
         logger.info("Command 'save' is running");
         player.save();
     }
 
-    @Command(command="monster", aliases="m", description="Monsters around you", debug=false)
+    @Command(command="monster", aliases={"m", "enemy"}, description="Monsters around you", debug=false)
     public void command_m() {
         List<Monster> monsterList = player.getLocation().getMonsters();
         if (monsterList.size() > 0) {
@@ -128,7 +128,7 @@ public enum CommandCollection {
         }
     }
 
-    @Command(command="go", aliases="g", description="Goto a direction", debug=false)
+    @Command(command="go", aliases={"g"}, description="Goto a direction", debug=false)
     public void command_g(String arg) throws DeathException {
         ILocation location = player.getLocation();
 
@@ -179,16 +179,16 @@ public enum CommandCollection {
         }
     }
 
-    @Command(command="inspect", aliases = {"lookat", "i"}, description="Inspect an item", debug=false)
+    @Command(command="inspect", aliases = {"i", "lookat"}, description="Inspect an item", debug=false)
     public void command_i(String arg) { player.inspectItem(arg.trim()); }
 
-    @Command(command="equip", aliases= {"e", "pickup"}, description="Equip an item", debug=false)
+    @Command(command="equip", aliases= {"e"}, description="Equip an item", debug=false)
     public void command_e(String arg) { player.equipItem(arg.trim()); }
 
-    @Command(command="unequip", aliases="ue", description="Unequip an item", debug=false)
+    @Command(command="unequip", aliases={"ue"}, description="Unequip an item", debug=false)
     public void command_ue(String arg) { player.dequipItem(arg.trim()); }
 
-    @Command(command="view", aliases="v", description="View details for 'stats', 'equipped' or 'backpack'", debug=false)
+    @Command(command="view", aliases={"v"}, description="View details for 'stats', 'equipped' or 'backpack'", debug=false)
     public void command_v(String arg) {
         arg = arg.trim();
         switch (arg) {
@@ -210,27 +210,27 @@ public enum CommandCollection {
         }
     }
 
-    @Command(command="pick", aliases="p", description="Pick up an item", debug=false)
+    @Command(command="pick", aliases={"p", "pickup"}, description="Pick up an item", debug=false)
     public void command_p(String arg) { player.pickUpItem(arg.trim()); }
 
-    @Command(command="drop", aliases="d", description="Drop an item", debug=false)
+    @Command(command="drop", aliases={"d"}, description="Drop an item", debug=false)
     public void command_d(String arg) { player.dropItem(arg.trim()); }
 
-    @Command(command="attack", aliases="a", description="Attacks an entity", debug=false)
+    @Command(command="attack", aliases={"a"}, description="Attacks an entity", debug=false)
     public void command_a(String arg) throws DeathException { player.attack(arg.trim()); }
 
-    @Command(command="lookaround", aliases="la", description="Displays the description of the room you are in.", debug=false)
+    @Command(command="lookaround", aliases={"la"}, description="Displays the description of the room you are in.", debug=false)
     public void command_la() { player.getLocation().print(); }
 
     // Debug methods here
 
-    @Command(command="attack", aliases="", description="Adjusts the damage level the player has", debug=true)
+    @Command(command="attack", aliases={""}, description="Adjusts the damage level the player has", debug=true)
     public void command_attack(String arg) {
         double damage = Double.parseDouble(arg);
         player.setDamage(damage);
     }
 
-    @Command(command="maxhealth", aliases="", description="Adjusts the maximum health of the player", debug=true)
+    @Command(command="maxhealth", aliases={""}, description="Adjusts the maximum health of the player", debug=true)
     public void command_maxhealth(String arg) {
         int healthMax = Integer.parseInt(arg);
         if (healthMax > 0) {
@@ -240,7 +240,7 @@ public enum CommandCollection {
         }
     }
 
-    @Command(command="health", aliases="", description="Adjusts the amount of gold the player has", debug=true)
+    @Command(command="health", aliases={""}, description="Adjusts the amount of gold the player has", debug=true)
     public void command_health(String arg) {
         int health = Integer.parseInt(arg);
         if (health > 0) {
@@ -250,25 +250,25 @@ public enum CommandCollection {
         }
     }
 
-    @Command(command="armour", aliases="", description="Adjusts the amount of armour the player has", debug=true)
+    @Command(command="armour", aliases={""}, description="Adjusts the amount of armour the player has", debug=true)
     public void command_armour(String arg) {
         int armour = Integer.parseInt(arg);
         player.setArmour(armour);
     }
 
-    @Command(command="level", aliases="", description="Adjusts the level of the player", debug=true)
+    @Command(command="level", aliases={""}, description="Adjusts the level of the player", debug=true)
     public void command_level(String arg) {
         int level = Integer.parseInt(arg);
         player.setLevel(level);
     }
 
-    @Command(command="gold", aliases="", description="Adjusts the amount of gold the player has", debug=true)
+    @Command(command="gold", aliases={""}, description="Adjusts the amount of gold the player has", debug=true)
     public void command_gold(String arg) {
         int gold = Integer.parseInt(arg);
         player.setGold(gold);
     }
 
-    @Command(command="teleport", aliases="", description="Moves the player to specified coordinates", debug=true)
+    @Command(command="teleport", aliases={""}, description="Moves the player to specified coordinates", debug=true)
     public void command_teleport(String arg) {
         LocationRepository locationRepo = GameBeans.getLocationRepository(player.getName());
         ILocation newLocation = locationRepo.getLocation(new Coordinate(arg));
@@ -282,12 +282,12 @@ public enum CommandCollection {
         }
     }
 
-    @Command(command="backpack", aliases="", description="Opens the backpack debug menu.", debug=true)
+    @Command(command="backpack", aliases={""}, description="Opens the backpack debug menu.", debug=true)
     public void command_backpack(String arg) {
         new BackpackDebugPrompt(player);
     }
 
-    @Command(command="talk", aliases="t", description="Talks to a character.", debug=false)
+    @Command(command="talk", aliases={"talk", "speakto"}, description="Talks to a character.", debug=false)
     public void command_talk(String arg) throws DeathException {
         ConversationManager cm = new ConversationManager();
         List<NPC> npcs = player.getLocation().getNpcs();

--- a/src/main/java/com/jadventure/game/prompts/CommandParser.java
+++ b/src/main/java/com/jadventure/game/prompts/CommandParser.java
@@ -2,6 +2,7 @@ package com.jadventure.game.prompts;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.TreeMap;
 
 import com.jadventure.game.DeathException;
@@ -34,7 +35,7 @@ public class CommandParser {
             }
             Command annotation = method.getAnnotation(Command.class);
             this.commandMap.put(annotation.command(), method);
-            for(String alias : annotation.aliases().split(",")){
+            for(String alias : annotation.aliases()){
                 if (alias.length() == 0) {
                     break;
                 }
@@ -78,7 +79,7 @@ public class CommandParser {
                             }
                         }
                     } else {
-                        QueueProvider.offer("I don't know what'" + userCommand + "' means.");
+                        QueueProvider.offer("I don't know what '" + userCommand + "' means.");
                         return true;
                     }
                 } else if (method.getParameterTypes()[0] == String.class) {
@@ -104,7 +105,7 @@ public class CommandParser {
                 return true;
             }
         }
-        QueueProvider.offer("I don't know what'" + userCommand + "' means.");
+        QueueProvider.offer("I don't know what '" + userCommand + "' means.");
         return true;
     }
 


### PR DESCRIPTION
# New Feature
Multiple Aliases Support

# Description

Added support for commands to have multiple aliases in-case players of the game wanted a wider range of options for executing certain actions. Examples include:

`inspect` - `['i', 'lookat']`
`pick` - `['p', 'pickup']`

Other aliases can be added too. 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Test A - Test that the aliases for the inspect command execute the same method
- [x] Test B - Test that the aliases for the pick command execute the same method

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings